### PR TITLE
add stats_users config

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -52,6 +52,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
+stats_users = ${DB_USER}
 [databases]
 EOFEOF
 


### PR DESCRIPTION
add `stats_users` config so we can access the pgbouncer admin console - 
http://pgbouncer.projects.pgfoundry.org/doc/usage.html#_admin_console
